### PR TITLE
chore: update wilsonthewolf uri

### DIFF
--- a/configs/index-list/wilsonthewolf.yaml
+++ b/configs/index-list/wilsonthewolf.yaml
@@ -1,3 +1,3 @@
 ranking: 3
 slug: wilsonthewolf
-uri: https://wilsonthewolf.github.io/repo
+uri: https://repo.shorty.systems


### PR DESCRIPTION
I am the owner of the wilsonthewolf repo. Specifically, the old repo does properly redirect to my new domain. Interestingly, canister does not seem to respect this redirect, returning a 404 for my slug. Maybe that should be checked out. Thanks!