### PR TITLE
chore: update ironside-strap conf

### DIFF
--- a/configs/index-list/ironside-strap.yaml
+++ b/configs/index-list/ironside-strap.yaml
@@ -1,3 +1,5 @@
+suite: darwin-amd64
 ranking: 1
 slug: ironside-strap
-uri: https://mac.ironside.org.uk
+component: main
+uri: https://apt.ironside.org.uk/


### PR DESCRIPTION
forgor to update this one; all ironside repos should now be under dist type