### PR TITLE
chore: fix ironside conf

### DIFF
--- a/configs/index-list/ironside.yaml
+++ b/configs/index-list/ironside.yaml
@@ -3,4 +3,4 @@ ranking: 3
 slug: ironside
 component: main
 uri: https://apt.ironside.org.uk/
-bootstrap: true
+


### PR DESCRIPTION
the iphoneos-arm dist is not a bootstrap, only darwin-amd64.