### PR TITLE
chore: add ploosh repo

### DIFF
--- a/configs/index-list/ploosh.yml
+++ b/configs/index-list/ploosh.yml
@@ -1,0 +1,4 @@
+ranking: 3
+slug: ploosh
+component: main
+uri: https://repo.ploosh.dev


### PR DESCRIPTION
This pr adds my repo so it can be indexed by Canister. The repo is will WIP, and will contain tweaks/packages I develop. I am the original author of debstealer, and I gave Ironside permission to host it. It supports rootful and rootless, so the architecture is left out.