### PR TITLE
chore: rename ironside-strap to ironside-mac

### DIFF
--- a/configs/index-list/ironside-mac.yaml
+++ b/configs/index-list/ironside-mac.yaml
@@ -1,6 +1,6 @@
 suite: darwin-amd64
 ranking: 1
-slug: ironside-strap
+slug: ironside-mac
 component: main
 uri: https://apt.ironside.org.uk/
 bootstrap: true


### PR DESCRIPTION
hopefully force canister to index new url