### PR TITLE
chore: index keycap's repo

### DIFF
--- a/configs/index-list/keycap.yml
+++ b/configs/index-list/keycap.yml
@@ -1,0 +1,3 @@
+ranking: 3
+slug: keycap
+uri: https://repo.keycap.one


### PR DESCRIPTION
Hi there, I've started a repo to host updated tweaks for iOS 15 that the original devs either stopped working on or have no plans to continue. I also have some works of my own, so I'd like to index the repo. Thanks.