### PR TITLE
Removing Zeus.

### DIFF
--- a/configs/index-list/zeus.yaml
+++ b/configs/index-list/zeus.yaml
@@ -1,3 +1,0 @@
-ranking: 4
-slug: zeus
-uri: https://zeusteam.dev/


### PR DESCRIPTION
Zeus is no longer hosting a jailbreak repo.