### PR TITLE
Remove repo.alexia.lol

### DIFF
--- a/configs/index-list/alexia.yaml
+++ b/configs/index-list/alexia.yaml
@@ -1,7 +1,0 @@
-aliases:
-  - nyuszika7h
-  - nyu
-  - cadoth
-ranking: 3
-slug: alexia
-uri: https://repo.alexia.lol


### PR DESCRIPTION
repo.alexia.lol redirects anyone in the United Kingdom to an (unofficial) site for a petition to stop the E2EE backdoor act from going through in the parliament.
However, this is not useful as most who use this repo are end users who have no idea about this act or petition and wouldnt want to sign it. Additionally, in package managers such as Sileo, the redirect doesn't even show, meaning the repo just doesn't work anymore.
TLDR; Repo doesn't work for anyone in the UK, redirects to bogus petition instead. 