### PR TITLE
feat: add repo.thanos.lol

### DIFF
--- a/configs/index-list/whitetail.yaml
+++ b/configs/index-list/whitetail.yaml
@@ -1,0 +1,3 @@
+ranking: 3
+slug: WhitetailAni
+uri: https://repo.thanos.lol


### PR DESCRIPTION
Mainly proposing addition as it has the DerootifierDepends package on its rootless side. It's a dummy package that just installs all the Derootifier dependencies as it lists them as depends. Rootful repo has a few useful things for legacy devices as well (all under same URL)