### PR TITLE
chore: remove generic yourepo

### DIFF
--- a/configs/index-list/yourepo.yaml
+++ b/configs/index-list/yourepo.yaml
@@ -1,3 +1,0 @@
-ranking: 4
-slug: yourepo
-uri: https://www.yourepo.com


### PR DESCRIPTION
The generic YouRepo repo is filled with mostly garbage. If any packages are missing (unlikely), the user's personal YouRepo repo should be PR'd.