### PR TITLE
fix: new enmity URI

### DIFF
--- a/configs/index-list/enmity.yaml
+++ b/configs/index-list/enmity.yaml
@@ -1,3 +1,3 @@
 ranking: 3
 slug: enmity
-uri: https://repo.enmity.app/
+uri: https://enmity-mod.github.io/repo


### PR DESCRIPTION
Due to various circumstances in the past, the Enmity domain is no longer being renewed due to an upcoming new rewrite going under a new name.