### PR TITLE
chore: rename bigfloppa234 repo to ceilingtilefan repo

### DIFF
--- a/configs/index-list/bigfloppa234.yaml
+++ b/configs/index-list/bigfloppa234.yaml
@@ -1,3 +1,0 @@
-ranking: 3
-slug: bigfloppa234
-uri: https://bigfloppa234.github.io/repo

--- a/configs/index-list/ceilingtilefan.yaml
+++ b/configs/index-list/ceilingtilefan.yaml
@@ -1,0 +1,3 @@
+ranking: 3
+slug: ceilingtilefan
+uri: https://ceilingtilefan.github.io/repo


### PR DESCRIPTION
renamed github account so previous url no longer works