### PR TITLE
chore: update hg13.yaml

### DIFF
--- a/configs/index-list/hg13.yaml
+++ b/configs/index-list/hg13.yaml
@@ -1,3 +1,3 @@
 ranking: 3
 slug: hg13
-uri: https://hg13bs.me
+uri: https://hg13bs.github.io


### PR DESCRIPTION
The domain expired, defaulting back to my GitHub page for now